### PR TITLE
2019-08-05 Added CMYK/CMYKa support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -228,6 +228,10 @@ export class Color {
         c.a = input.a !== undefined ? toFlt(input.a) : undefined;
         return new Color(c);
       }
+      // (rr01) 2019-08-05 New color conversion CMYK(a) to RGB(a)
+      if (input.c !== undefined) {
+        return Color.fromCMYK(input);
+      }
       return this;
     }
     return Color.fromArray([0, 0, 0]);
@@ -325,6 +329,26 @@ export class Color {
       g: float2Byte(m + g),
       b: float2Byte(m + b)
     });
+  }
+  // (rr01) 2019-08-05 New color conversion CMYK(a) to RGB(a)
+  static fromCMYK( {c, m, y, k, a} ){
+    let r=0,g=0,b=0;
+
+    c /= 100;
+    m /= 100;
+    y /= 100;
+    k /= 100;
+
+    r = 1 - Math.min( 1, c * ( 1 - k ) + k );
+    g = 1 - Math.min( 1, m * ( 1 - k ) + k );
+    b = 1 - Math.min( 1, y * ( 1 - k ) + k );
+
+    r = float2Byte(r);
+    g = float2Byte(g);
+    b = float2Byte(b);
+  
+  if (a) return new Color( { r,b,g,a:toFlt(a) } )
+  else   return new Color( { r,b,g } );
   }
 
   /** Getters **/
@@ -429,6 +453,32 @@ export class Color {
       a: this.alpha
     };
   }
+  // (rr01) 2019-08-05 New color conversion RGB(a) to CMYK(a)
+  get cmyk(){
+    var c,m,y,k;
+
+    const r = parseFloat(this.r)/255.0;
+    const g = parseFloat(this.g)/255.0;
+    const b = parseFloat(this.b)/255.0;
+
+    k = 1-Math.max(r,g,b);
+
+    if (k==1) c=m=y=0;
+    else {
+      c = (1-r-k)/(1-k);
+      m = (1-g-k)/(1-k);
+      y = (1-b-k)/(1-k);
+    }
+
+    c = Math.round(100*c);
+    m = Math.round(100*m);
+    y = Math.round(100*y);
+    k = Math.round(100*k);
+
+  if (this.alpha) return { c,m,y,k,a: this.alpha }
+  else            return { c,m,y,k };
+  }
+
   get hslString() {
     const hsl = this.hsl;
     return `hsl(${hsl.h}, ${hsl.s}%, ${hsl.l}%)`;
@@ -438,8 +488,18 @@ export class Color {
     return `hsla(${hsl.h}, ${hsl.s}%, ${hsl.l}%, ${hsl.a})`;
   }
 
+  // (rr01) 2019-08-05 New color conversion CMYK(a)
+  get cmykString() {
+    const cmyk = this.cmyk;
+    return `cmyk(${cmyk.c}%, ${cmyk.m}%, ${cmyk.y}%, ${cmyk.k}%)`;
+  }
+  get cmykaString() {
+    const cmyk = this.cmyk;
+    return `cmyka(${cmyk.c}%, ${cmyk.m}%, ${cmyk.y}%, ${cmyk.k}%, ${cmyk.a})`;
+  }
+
   /** Functions **/
-  toString(format = 'rgb') {// accepts rgb, rgbaHex, hex, hsl, hsla
+  toString(format = 'rgb') {// accepts rgb, rgbaHex, hex, hsl, hsla, (rr01) cmyk, cmyka
     let s;
     switch (format) {
       case 'rgb':
@@ -457,6 +517,15 @@ export class Color {
       case 'hsla':
         s = this.hslaString;
         break;
+
+      // (rr01) 2019-08-05 New color conversion CMYK(a)
+      case 'cmyk':
+        s = this.cmykString;
+        break;
+      case 'cmyka':
+        s = this.cmykaString;
+        break;
+
       default :
         s = this.rgbString;
         break;


### PR DESCRIPTION
Hey Ron,
I've added CMYK(a) support as discussed. From, To, String and Functions (just to be complete as cmyk() and cmyka() are not supported by W3).

Needed to create a local copy first without 'export' keywords as I don't use Vue, npm, node, etc. for my little JS requirements, so double-check!

used below code in HTML to check new functionality.

Cheers, Rene

`<script>
const c = new Color({c:52, m:0, y:17, k:54, a:0.33} );
console.log(c); // yields r:56, g:117, b:97 => OK
console.log(c.rgb);
console.log(c.cmyk);
console.log(c.hsl);

console.log(c.hslString);
console.log(c.hslaString);

console.log(c.cmykString);
console.log(c.cmykaString);

console.log(c.hex);
</script>
`